### PR TITLE
🐛 remove duplicate instruction to draw scoreLabel

### DIFF
--- a/docs/tut-making-shooter.md
+++ b/docs/tut-making-shooter.md
@@ -488,12 +488,6 @@ this.scoreLabel.x = 30;
 this.scoreLabel.y = 30;
 ```
 
-We should also add this line to the `Draw` tab so that the label is updated each frame:
-
-```js
-this.scoreLabel.text = 'Score: ' + this.score;
-```
-
 ::: tip
 `ct.styles.get('Style');` loads the given style. You can use it inside PIXI.Text constructor to style the created label.
 :::


### PR DESCRIPTION
Readers were instructed two times to add functionality to the Draw of the room.
For me, personally this lead to doubting myself while reading through thinking "wait, didn't I just do that?!?". Thus, I propose removing the second occurrence.