### PR TITLE
🐛 Docs: Fix incorrect links under docs/modding-ctjs

### DIFF
--- a/docs/modding-ctjs/fields-declaration.md
+++ b/docs/modding-ctjs/fields-declaration.md
@@ -1,6 +1,6 @@
 # Fields reference for module settings and additional fields
 
-Both [module settings](modding/settings-and-extensions.html) and extensions for built-in templates are implemented by writing a declaration of editable fields in `module.json`. A declaration is an array of objects, with each object being one editable field. Let's take a look at `ct.place` module and its `module.json` (look at the `fields` array):
+Both [module settings](./settings-and-extensions.html) and extensions for built-in templates are implemented by writing a declaration of editable fields in `module.json`. A declaration is an array of objects, with each object being one editable field. Let's take a look at `ct.place` module and its `module.json` (look at the `fields` array):
 
 ```json
 {

--- a/docs/modding-ctjs/input-methods.md
+++ b/docs/modding-ctjs/input-methods.md
@@ -32,7 +32,7 @@ ct.inputs.registry['keyboard.keyW'] = 1;
 ct.inputs.registry['gamepad.LeftThumbX'] = 0.2;
 ```
 
-Depending on the input method you are implementing and its native API, you may need checking them at each frame with [injections](modding/events-and-injections.html), or listen to their events.
+Depending on the input method you are implementing and its native API, you may need checking them at each frame with [injections](./events-and-injections.html), or listen to their events.
 
 ## Examples
 

--- a/docs/modding-ctjs/settings-and-extensions.md
+++ b/docs/modding-ctjs/settings-and-extensions.md
@@ -56,9 +56,9 @@ Here is how the screen above was implemented:
 }
 ```
 
-There are actually more input types; all of them, as well as description of other keys, can be found in [Fields declarations](modding/fields-declaration.html) page.
+There are actually more input types; all of them, as well as description of other keys, can be found in [Fields declarations](./fields-declaration.html) page.
 
-Settings' values are used for templating in your index.js and injections. Injections allow you to place your code in particular ct.js events. More about them and templating [here](modding/events-and-injections.html).
+Settings' values are used for templating in your index.js and injections. Injections allow you to place your code in particular ct.js events. More about them and templating [here](./events-and-injections.html).
 
 ## Adding extensions to built-in assets
 


### PR DESCRIPTION
A few files under `docs/modding-ctjs` had links that lead to `./modding/example.ex` instead of `./example.ex`.

The folder `docs/modding-ctjs/modding` doesn't exist and trying to go to those links in docs.ctjs.rocks results in a 404, so this pull request fixes those links.

@CosmoMyzrailGorynych 