### PR TITLE
📝 Docs: Minor Documentation Fixes

### DIFF
--- a/docs/modding-ctjs/events-and-injections.md
+++ b/docs/modding-ctjs/events-and-injections.md
@@ -2,7 +2,7 @@
 
 Injections are a powerful instrument to extend functionality of ct.js framework beyond adding methods or properties. It allows you to add logic to a game loop, load resources, create bundled Templates, etc.
 
-The `injects` folder inside your module's directory accepts files with code that will be injected while exporting a game. All of them are optional, and here is a list of all the possible injections:
+The `injections` folder inside your module's directory accepts files with code that will be injected while exporting a game. All of them are optional, and here is a list of all the possible injections:
 
 **General events**:
 

--- a/docs/modding-ctjs/fields-declaration.md
+++ b/docs/modding-ctjs/fields-declaration.md
@@ -78,7 +78,7 @@ declare interface IExtensionField {
 
 Here we mark optional fields in form of `key?: type`. The required fields are `name` and `type`. The former is a text label that is shown before an input field; the latter is a string that defines input method displayed for a user. It can be one of these strings:
 
-* `input` — a simple text input for short strings;
+* `text` — a simple text input for short strings;
 * `textfield` — a large textarea for a long input;
 * `code` — similar to `textfield`, but with monospace font and usually wider than `textfield`;
 * `number` — an input field for integers;

--- a/docs/modding-ctjs/mod-structure.md
+++ b/docs/modding-ctjs/mod-structure.md
@@ -35,7 +35,7 @@ mycatmod
   |-- includes
   |   \-- (files to be copied to a resulting game)
   |
-  \-- injects
+  \-- injections
       \-- (injections go here)
 ```
 (more about injections [here](./events-and-injections.html))

--- a/docs/pt_BR/modding-events-and-injections.md
+++ b/docs/pt_BR/modding-events-and-injections.md
@@ -2,7 +2,7 @@
 
 Injeções são um poderoso intrumento para estender as funcionalidade do framework ct.js além de adicionar métodos e propriedades. Permitindo que você adicione lógica para um loop de jogo, carregue recursos. crie templates agrupados e etc.
 
-A pasta `injects` dentro do diretório do seu módulo aceita arquivos com código que serão injetados quando exportar um jogo. Todos eles são opcionais, e aqui está uma lista com todas as injeções possíveis:
+A pasta `injections` dentro do diretório do seu módulo aceita arquivos com código que serão injetados quando exportar um jogo. Todos eles são opcionais, e aqui está uma lista com todas as injeções possíveis:
 
 **Eventos gerais**:
 

--- a/docs/pt_BR/modding-structure.md
+++ b/docs/pt_BR/modding-structure.md
@@ -22,7 +22,7 @@ mycatmod
   |-- includes
   |   \-- (arquivos a serem copiados para o jogo resultante)
   |
-  \-- injects
+  \-- injections
       \-- (injeções vão aqui)
 ```
 (mais sobre injeções [aqui](./modding-events-and-injections.html))


### PR DESCRIPTION
List of stuff this fixes:
  -  renames `input` to `text` in `docs/modding-ctjs/fields-declaration.md`
       -  The non-existent `input` field type is supposed to be `text`, as evident in [`ct-js/ct-js` / `src/riotTags/shared/extensions-editor.tag`](https://github.com/ct-js/ct-js/blob/develop/src/riotTags/shared/extensions-editor.tag)
  -  renames `injects` to `injections` in `docs/modding-ctjs/events-and-injections.md`, `docs/modding-ctjs/mod-structure.md` (and the same files under`docs/pt_BR/...`)
       -  the `injects` folder was renamed to `injections` in all of ct-js/ct-js in commit `bf721cd` (https://github.com/ct-js/ct-js/commit/bf721cdb6f87ca667dc8c9140440eaba5fa7098c), but that change was never reflected in ct-js/docs.ctjs.rocks