### PR TITLE
🐛 Replace this.depth with this.zIndex

### DIFF
--- a/docs/ct.emitters.md
+++ b/docs/ct.emitters.md
@@ -108,7 +108,7 @@ ct.emitters.follow(this, 'Debuff', {
         y: -80
     },
     tint: 0xff9999,
-    depth: this.depth
+    depth: this.zIndex
 });
 ```
 @tab CoffeeScript

--- a/docs/pt_BR/ct.emitters.md
+++ b/docs/pt_BR/ct.emitters.md
@@ -74,7 +74,7 @@ ct.emitters.follow(this, 'Debuff', {
         y: -80
     },
     tint: 0xff9999,
-    depth: this.depth
+    depth: this.zIndex
 });
 ```
 


### PR DESCRIPTION
Closes #115 

Replaced `this.depth` with `this.zIndex` as it has become depreciated.

<br></br>
@CosmoMyzrailGorynych 