### PR TITLE
🐛 Fix Discord Link

### DIFF
--- a/docs/.vuepress/localeIt.js
+++ b/docs/.vuepress/localeIt.js
@@ -16,7 +16,7 @@ export default {
         },
         {
             text: "Discord",
-            link: "https://discord.gg/CggbPkb",
+            link: "https://discord.gg/yuvuDW5",
         },
         {
             text: "Forum",

--- a/docs/.vuepress/localePtBR.js
+++ b/docs/.vuepress/localePtBR.js
@@ -17,7 +17,7 @@ export default {
         },
         {
             text: "Discord",
-            link: "https://discord.gg/CggbPkb",
+            link: "https://discord.gg/yuvuDW5",
         },
         {
             text: "Fórum",

--- a/docs/.vuepress/themeConfig.js
+++ b/docs/.vuepress/themeConfig.js
@@ -69,7 +69,7 @@ export default {
         },
         {
             text: "Discord",
-            link: "https://discord.gg/CggbPkb",
+            link: "https://discord.gg/yuvuDW5",
             icon: 'user-group'
         },
         {

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ footer: Ct.js documentation. Except where otherwise noted, content is licensed u
         <div class="feature" style="flex-basis: 50%;">
             <h2>Join the community</h2>
             <p>Join our Discord server to meet other game developers, receive help, aid others, and share your creations. Alternatively, you can also post on our forum.</p>
-            <a class="action-button" target="_blank" href="https://discord.gg/CggbPkb">Discord Server →</a>
+            <a class="action-button" target="_blank" href="https://discord.gg/yuvuDW5">Discord Server →</a>
             <a class="action-button" target="_blank" href="https://forum.ctjs.rocks/">Forum →</a>
         </div>
         <div class="feature"  style="flex-basis: 50%;">

--- a/docs/it/README.md
+++ b/docs/it/README.md
@@ -53,7 +53,7 @@ footer: Ct.js documentazione. Salvo diversa indicazione, al contenuto si applica
         <div class="feature"  style="flex-basis: 50%;">
             <h2>Unisciti alla comunità</h2>
             <p>Unisciti al nostro server Discord per incontrare altri sviluppatori di giochi, ricevere aiuto, aiutare gli altri e condividere le tue creazioni. In alternativa, puoi anche postare sul nostro forum.</p>
-            <a class="action-button" target="_blank" href="https://discord.gg/CggbPkb">Server Discord →</a>
+            <a class="action-button" target="_blank" href="https://discord.gg/yuvuDW5">Server Discord →</a>
             <a class="action-button" target="_blank" href="https://comigo.itch.io/ct/community">Forum →</a>
         </div>
         <div class="feature"  style="flex-basis: 50%;">

--- a/docs/pt_BR/README.md
+++ b/docs/pt_BR/README.md
@@ -51,7 +51,7 @@ footer: Documentação ct.js. Exceto onde for indicado de outra forma, o conteú
         <div class="feature"  style="flex-basis: 50%;">
             <h2>Junte-se à comunidade</h2>
             <p>Junte-se ao nosso servidor Discord para conhecer outros desenvolvedores de jogos, tire dúvidas, ajude aos outros e compartilhe as suas criações. Além disso, você pode também postar em nosso fórum.</p>
-            <a class="action-button" target="_blank" href="https://discord.gg/CggbPkb">Servidor Discord →</a>
+            <a class="action-button" target="_blank" href="https://discord.gg/yuvuDW5">Servidor Discord →</a>
             <a class="action-button" target="_blank" href="https://forum.ctjs.rocks/">Fórum →</a>
         </div>
         <div class="feature"  style="flex-basis: 50%;">

--- a/docs/troubleshooting/migration-2to3.md
+++ b/docs/troubleshooting/migration-2to3.md
@@ -14,4 +14,4 @@ This is rare and will probably happen to those who used ct.js Nightly before v3 
 
 Sometimes textures, generated with ct.js, will break project loading or room editor. You can fix it by opening your project's `img` folder, and removing `}` symbol in placeholder textures' filenames.
 
-If you need help, write to our [Discord server](https://discord.gg/CggbPkb)!
+If you need help, write to our [Discord server](https://discord.gg/yuvuDW5)!


### PR DESCRIPTION
Description:

The old discord invite `CggbPkb` no longer works, it was updated everywhere on the website, so I updated it in the docs too.

Changes:

This only replaces the link for the English discord server, the Russian invite link still works. (I made sure I didn't accidentally mix up the English and Russian links)